### PR TITLE
Delete 'my profil' link  bug in the navbar

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -71,11 +71,14 @@
 
                     </li>
 
+
+                    {% if (app.user) %}
                     <li class="nav-item d-md-none">
 
                         <a class="nav-link click-scroll" href="{{ path('app_current_user_profile') }}">Mon Profil</a>
 
                     </li>
+                    {% endif %}
 
                 </ul>
 


### PR DESCRIPTION
Hello ! Petite modification concernant une erreur dans la navbar (le lien vers la page "Mon profil" était disponible même lorsqu'aucun utilisateur n'était connecté).